### PR TITLE
feat: support template variables in system prompt

### DIFF
--- a/internal/adapter/openai.go
+++ b/internal/adapter/openai.go
@@ -111,11 +111,11 @@ func (a *OpenAIAdapter) Type() string { return "openai" }
 func (a *OpenAIAdapter) buildMessages(req *ChatRequest) []openAIMessage {
 	var messages []openAIMessage
 
-	// 系统提示词
+	// 系统提示词（支持模板变量替换）
 	if a.systemPrompt != "" {
 		messages = append(messages, openAIMessage{
 			Role:    "system",
-			Content: a.systemPrompt,
+			Content: ExpandPromptVars(a.systemPrompt, a.model),
 		})
 	}
 

--- a/internal/adapter/template.go
+++ b/internal/adapter/template.go
@@ -1,0 +1,55 @@
+package adapter
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// ExpandPromptVars 展开系统提示词中的模板变量
+// 支持的变量：
+//   - {cur_date}     当前日期，格式 2006-01-02
+//   - {cur_time}     当前时间，格式 15:04:05
+//   - {cur_datetime} 完整日期时间，格式 2006-01-02 15:04:05
+//   - {model_id}     当前使用的模型 ID
+//   - {model_name}   模型名称（同 model_id）
+//   - {locale}       系统语言环境（如 zh-CN、en-US）
+func ExpandPromptVars(prompt string, modelID string) string {
+	// 快速路径：不含变量标记时直接返回
+	if !strings.Contains(prompt, "{") {
+		return prompt
+	}
+
+	now := time.Now()
+	replacer := strings.NewReplacer(
+		"{cur_date}", now.Format("2006-01-02"),
+		"{cur_time}", now.Format("15:04:05"),
+		"{cur_datetime}", now.Format("2006-01-02 15:04:05"),
+		"{model_id}", modelID,
+		"{model_name}", modelID,
+		"{locale}", detectLocale(),
+	)
+	return replacer.Replace(prompt)
+}
+
+// detectLocale 检测系统语言环境
+func detectLocale() string {
+	// 优先读取 LANG / LC_ALL 环境变量
+	for _, env := range []string{"LC_ALL", "LANG", "LANGUAGE"} {
+		if val := os.Getenv(env); val != "" {
+			// 提取语言标签部分，如 "zh_CN.UTF-8" → "zh-CN"
+			locale := strings.Split(val, ".")[0]
+			locale = strings.ReplaceAll(locale, "_", "-")
+			return locale
+		}
+	}
+
+	// 根据操作系统返回默认值
+	switch runtime.GOOS {
+	case "darwin":
+		return "zh-CN" // macOS 中文环境常见
+	default:
+		return "en-US"
+	}
+}

--- a/internal/adapter/template_test.go
+++ b/internal/adapter/template_test.go
@@ -1,0 +1,80 @@
+package adapter
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExpandPromptVars_NoVars(t *testing.T) {
+	// 不含变量的提示词应原样返回
+	input := "你是一个友好的助手"
+	result := ExpandPromptVars(input, "gpt-4o")
+	if result != input {
+		t.Errorf("期望原样返回 %q，实际得到 %q", input, result)
+	}
+}
+
+func TestExpandPromptVars_DateVars(t *testing.T) {
+	input := "今天是 {cur_date}，时间 {cur_time}，完整 {cur_datetime}"
+	result := ExpandPromptVars(input, "gpt-4o")
+
+	today := time.Now().Format("2006-01-02")
+	if !strings.Contains(result, today) {
+		t.Errorf("期望包含日期 %q，实际: %q", today, result)
+	}
+
+	// 不应包含原始变量标记
+	for _, v := range []string{"{cur_date}", "{cur_time}", "{cur_datetime}"} {
+		if strings.Contains(result, v) {
+			t.Errorf("未替换变量 %q，结果: %q", v, result)
+		}
+	}
+}
+
+func TestExpandPromptVars_ModelVars(t *testing.T) {
+	input := "你正在使用 {model_id} 模型，名称为 {model_name}"
+	result := ExpandPromptVars(input, "deepseek-v3")
+
+	expected := "你正在使用 deepseek-v3 模型，名称为 deepseek-v3"
+	if result != expected {
+		t.Errorf("期望 %q，实际 %q", expected, result)
+	}
+}
+
+func TestExpandPromptVars_LocaleVar(t *testing.T) {
+	input := "请用 {locale} 回答"
+	result := ExpandPromptVars(input, "gpt-4o")
+
+	if strings.Contains(result, "{locale}") {
+		t.Errorf("未替换 {locale}，结果: %q", result)
+	}
+	// locale 应不为空
+	if result == "请用  回答" {
+		t.Errorf("locale 替换为空值")
+	}
+}
+
+func TestExpandPromptVars_MixedContent(t *testing.T) {
+	input := "日期 {cur_date}，模型 {model_id}，普通文本不变 {unknown_var}"
+	result := ExpandPromptVars(input, "gpt-4o")
+
+	// 已知变量应被替换
+	if strings.Contains(result, "{cur_date}") {
+		t.Errorf("未替换 {cur_date}")
+	}
+	if strings.Contains(result, "{model_id}") {
+		t.Errorf("未替换 {model_id}")
+	}
+	// 未知变量应保留原样
+	if !strings.Contains(result, "{unknown_var}") {
+		t.Errorf("未知变量不应被替换: %q", result)
+	}
+}
+
+func TestExpandPromptVars_EmptyPrompt(t *testing.T) {
+	result := ExpandPromptVars("", "gpt-4o")
+	if result != "" {
+		t.Errorf("空字符串应返回空，实际: %q", result)
+	}
+}

--- a/web/src/pages/Adapters.tsx
+++ b/web/src/pages/Adapters.tsx
@@ -271,14 +271,24 @@ export function AdaptersPage({ onUpdate }: Props) {
 
                   <div className="grid grid-cols-4 items-start gap-4">
                     <Label htmlFor="adapter-prompt" className="text-right pt-3">系统提示</Label>
-                    <Textarea
-                      id="adapter-prompt"
-                      value={form.system_prompt}
-                      onChange={e => setForm({ ...form, system_prompt: e.target.value })}
-                      className="col-span-3"
-                      rows={3}
-                      placeholder="你是一个友好的微信助手..."
-                    />
+                    <div className="col-span-3 space-y-2">
+                      <Textarea
+                        id="adapter-prompt"
+                        value={form.system_prompt}
+                        onChange={e => setForm({ ...form, system_prompt: e.target.value })}
+                        rows={3}
+                        placeholder="你是一个友好的微信助手..."
+                      />
+                      <p className="text-muted-foreground text-xs leading-relaxed">
+                        支持变量：
+                        <code className="mx-0.5 rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{'{cur_date}'}</code>
+                        <code className="mx-0.5 rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{'{cur_time}'}</code>
+                        <code className="mx-0.5 rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{'{cur_datetime}'}</code>
+                        <code className="mx-0.5 rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{'{model_id}'}</code>
+                        <code className="mx-0.5 rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{'{model_name}'}</code>
+                        <code className="mx-0.5 rounded bg-muted px-1 py-0.5 font-mono text-[11px]">{'{locale}'}</code>
+                      </p>
+                    </div>
                   </div>
                 </>
               )}


### PR DESCRIPTION
## 概述

在 `system_prompt` 中支持动态模板变量，发送前自动替换为运行时值。

## 支持的变量

| 变量 | 说明 | 示例值 |
|------|------|--------|
| `{cur_date}` | 当前日期 | `2026-03-26` |
| `{cur_time}` | 当前时间 | `22:30:15` |
| `{cur_datetime}` | 完整日期时间 | `2026-03-26 22:30:15` |
| `{model_id}` | 模型 ID | `gpt-4o` |
| `{model_name}` | 模型名称 | `gpt-4o` |
| `{locale}` | 语言环境 | `zh-CN` |

## 变更内容

- **新增** `internal/adapter/template.go` — 模板变量替换引擎
- **新增** `internal/adapter/template_test.go` — 6 个单元测试（全部通过）
- **修改** `internal/adapter/openai.go` — `buildMessages` 中集成变量替换
- **修改** `web/src/pages/Adapters.tsx` — 系统提示词表单下方显示可用变量提示

## 测试

```
=== RUN   TestExpandPromptVars_NoVars       --- PASS
=== RUN   TestExpandPromptVars_DateVars     --- PASS
=== RUN   TestExpandPromptVars_ModelVars    --- PASS
=== RUN   TestExpandPromptVars_LocaleVar    --- PASS
=== RUN   TestExpandPromptVars_MixedContent --- PASS
=== RUN   TestExpandPromptVars_EmptyPrompt  --- PASS
```

Closes #1