### PR TITLE
feat: add model list fetching with combobox selector

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -5,11 +5,13 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/amigoer/weclaw-proxy/internal/adapter"
 	"github.com/amigoer/weclaw-proxy/internal/router"
@@ -121,6 +123,7 @@ func (s *Server) registerRoutes() {
 	// API 路由
 	s.mux.HandleFunc("/api/status", s.cors(s.handleStatus))
 	s.mux.HandleFunc("/api/adapters", s.cors(s.handleAdapters))
+	s.mux.HandleFunc("/api/adapters/models", s.cors(s.handleModels))
 	s.mux.HandleFunc("/api/adapters/", s.cors(s.handleAdapterByName))
 	s.mux.HandleFunc("/api/routes", s.cors(s.handleRoutes))
 	s.mux.HandleFunc("/api/smart-routing", s.cors(s.handleSmartRouting))
@@ -631,4 +634,80 @@ func (s *Server) ListenAndServe(addr string) error {
 	}
 	fmt.Printf("🌐 管理面板: http://%s\n", displayAddr)
 	return http.ListenAndServe(addr, s.mux)
+}
+
+// handleModels 代理查询远端模型列表
+func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	baseURL := r.URL.Query().Get("base_url")
+	apiKey := r.URL.Query().Get("api_key")
+
+	if baseURL == "" {
+		s.jsonErr(w, "缺少 base_url 参数", http.StatusBadRequest)
+		return
+	}
+
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	// 构建远端请求 URL
+	modelsURL := baseURL + "/models"
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		s.jsonErr(w, "创建请求失败: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		s.jsonErr(w, "请求模型列表失败: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.jsonErr(w, "读取响应失败: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		s.jsonErr(w, fmt.Sprintf("远端返回 HTTP %d", resp.StatusCode), resp.StatusCode)
+		return
+	}
+
+	// 解析 OpenAI 格式的模型列表
+	var modelsResp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &modelsResp); err != nil {
+		// 非 OpenAI 标准格式，尝试返回原始响应
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+		return
+	}
+
+	// 提取模型 ID 列表
+	models := make([]string, 0, len(modelsResp.Data))
+	for _, m := range modelsResp.Data {
+		if m.ID != "" {
+			models = append(models, m.ID)
+		}
+	}
+
+	s.json(w, map[string]interface{}{"models": models})
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,6 +12,22 @@ export async function fetchAdapters() {
   return res.json()
 }
 
+// 查询远端可用模型列表
+export async function fetchModels(baseUrl: string, apiKey: string): Promise<string[]> {
+  const params = new URLSearchParams({ base_url: baseUrl })
+  if (apiKey && !apiKey.includes('****')) {
+    params.set('api_key', apiKey)
+  }
+  try {
+    const res = await fetch(`${API_BASE}/api/adapters/models?${params}`)
+    if (!res.ok) return []
+    const data = await res.json()
+    return data.models || []
+  } catch {
+    return []
+  }
+}
+
 export async function createAdapter(data: Record<string, unknown>) {
   const res = await fetch(`${API_BASE}/api/adapters`, {
     method: 'POST',

--- a/web/src/pages/Adapters.tsx
+++ b/web/src/pages/Adapters.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { fetchAdapters, createAdapter, updateAdapter, deleteAdapter } from '@/lib/api'
+import { fetchAdapters, createAdapter, updateAdapter, deleteAdapter, fetchModels } from '@/lib/api'
 
 // 适配器类型定义
 interface AdapterConfig {
@@ -42,6 +42,25 @@ const TYPE_COLORS: Record<string, 'default' | 'secondary' | 'outline'> = {
   cli: 'secondary',
 }
 
+// 预置常见模型列表
+const PRESET_MODELS = [
+  'gpt-4o',
+  'gpt-4o-mini',
+  'gpt-4.1',
+  'gpt-4.1-mini',
+  'gpt-4.1-nano',
+  'o3-mini',
+  'o4-mini',
+  'claude-sonnet-4-20250514',
+  'claude-3-7-sonnet-20250219',
+  'deepseek-chat',
+  'deepseek-reasoner',
+  'gemini-2.5-pro-preview-05-06',
+  'gemini-2.5-flash-preview-04-17',
+  'qwen-plus',
+  'qwen-turbo',
+]
+
 interface Props {
   onUpdate: () => void
 }
@@ -61,6 +80,8 @@ export function AdaptersPage({ onUpdate }: Props) {
     max_tokens: 4096,
     temperature: 0.7,
   })
+  const [modelOptions, setModelOptions] = useState<string[]>(PRESET_MODELS)
+  const [loadingModels, setLoadingModels] = useState(false)
 
   const loadAdapters = useCallback(async () => {
     try {
@@ -260,13 +281,39 @@ export function AdaptersPage({ onUpdate }: Props) {
                 <>
                   <div className="grid grid-cols-4 items-center gap-4">
                     <Label htmlFor="adapter-model" className="text-right">模型</Label>
-                    <Input
-                      id="adapter-model"
-                      value={form.model}
-                      onChange={e => setForm({ ...form, model: e.target.value })}
-                      className="col-span-3"
-                      placeholder="gpt-4o"
-                    />
+                    <div className="col-span-3 flex gap-2">
+                      <div className="relative flex-1">
+                        <Input
+                          id="adapter-model"
+                          value={form.model}
+                          onChange={e => setForm({ ...form, model: e.target.value })}
+                          placeholder="输入或选择模型"
+                          list="model-options"
+                        />
+                        <datalist id="model-options">
+                          {modelOptions.map(m => (
+                            <option key={m} value={m} />
+                          ))}
+                        </datalist>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="shrink-0 text-xs px-3"
+                        disabled={loadingModels || !form.base_url}
+                        onClick={async () => {
+                          setLoadingModels(true)
+                          const models = await fetchModels(form.base_url || '', form.api_key || '')
+                          if (models.length > 0) {
+                            setModelOptions(models)
+                          }
+                          setLoadingModels(false)
+                        }}
+                      >
+                        {loadingModels ? '加载中...' : '获取模型'}
+                      </Button>
+                    </div>
                   </div>
 
                   <div className="grid grid-cols-4 items-start gap-4">


### PR DESCRIPTION
## 概述

适配器配置时支持从远端获取可用模型列表，前端提供可搜索下拉选择替代纯手动输入。

## 变更内容

### 后端
- **修改** `internal/server/api.go` — 新增 `GET /api/adapters/models` 代理 API，转发查询远端 `/models` 端点

### 前端
- **修改** `web/src/lib/api.ts` — 新增 `fetchModels()` 函数
- **修改** `web/src/pages/Adapters.tsx`：
  - 模型字段改为 Input + datalist（可搜索下拉 + 自定义输入）
  - 预置 15 个常见模型（GPT-4o、DeepSeek、Gemini、Qwen 等）
  - "获取模型" 按钮动态拉取远端模型列表
  - 保留自定义输入能力兼容私有部署

Closes #2