### PR TITLE
feat: add native Gemini adapter with google_search tool support

### DIFF
--- a/cmd/weclaw-proxy/main.go
+++ b/cmd/weclaw-proxy/main.go
@@ -508,6 +508,8 @@ func registerAdapters(cfg *config.Config, r *router.Router, logger *slog.Logger)
 			a = adapter.NewWebhookAdapter(&acfgCopy, adapterLogger)
 		case "cli":
 			a = adapter.NewCLIAdapter(&acfgCopy, adapterLogger)
+		case "gemini":
+			a = adapter.NewGeminiAdapter(&acfgCopy, adapterLogger)
 		default:
 			logger.Warn("暂不支持的适配器类型，跳过",
 				"name", acfg.Name,

--- a/internal/adapter/gemini.go
+++ b/internal/adapter/gemini.go
@@ -1,0 +1,331 @@
+package adapter
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// Gemini 原生 API 适配器
+// 支持 Google Gemini API（AI Studio / Vertex AI），包含 google_search 搜索工具
+
+// geminiPart Gemini 消息块
+type geminiPart struct {
+	Text string `json:"text,omitempty"`
+}
+
+// geminiContent Gemini 消息内容
+type geminiContent struct {
+	Role  string       `json:"role"`
+	Parts []geminiPart `json:"parts"`
+}
+
+// geminiRequest Gemini generateContent 请求
+type geminiRequest struct {
+	Contents          []geminiContent    `json:"contents"`
+	SystemInstruction *geminiContent     `json:"systemInstruction,omitempty"`
+	Tools             []geminiTool       `json:"tools,omitempty"`
+	GenerationConfig  *geminiGenConfig   `json:"generationConfig,omitempty"`
+}
+
+// geminiTool 工具定义
+type geminiTool struct {
+	GoogleSearch *struct{} `json:"google_search,omitempty"`
+}
+
+// geminiGenConfig 生成配置
+type geminiGenConfig struct {
+	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
+	Temperature     float64 `json:"temperature,omitempty"`
+}
+
+// geminiResponse Gemini 响应
+type geminiResponse struct {
+	Candidates []struct {
+		Content struct {
+			Parts []geminiPart `json:"parts"`
+		} `json:"content"`
+		FinishReason     string `json:"finishReason"`
+		GroundingMetadata *struct {
+			SearchEntryPoint *struct {
+				RenderedContent string `json:"renderedContent"`
+			} `json:"searchEntryPoint"`
+			GroundingChunks []struct {
+				Web *struct {
+					URI   string `json:"uri"`
+					Title string `json:"title"`
+				} `json:"web"`
+			} `json:"groundingChunks"`
+		} `json:"groundingMetadata,omitempty"`
+	} `json:"candidates"`
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// GeminiAdapter Gemini 原生适配器
+type GeminiAdapter struct {
+	name           string
+	baseURL        string
+	apiKey         string
+	model          string
+	systemPrompt   string
+	maxTokens      int
+	temperature    float64
+	enableSearch   bool
+	httpClient     *http.Client
+	logger         *slog.Logger
+}
+
+// NewGeminiAdapter 创建 Gemini 适配器
+func NewGeminiAdapter(cfg *AdapterConfig, logger *slog.Logger) *GeminiAdapter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://generativelanguage.googleapis.com"
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	model := cfg.Model
+	if model == "" {
+		model = "gemini-2.5-flash-preview-04-17"
+	}
+
+	maxTokens := cfg.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = 8192
+	}
+
+	temperature := cfg.Temperature
+	if temperature == 0 {
+		temperature = 0.7
+	}
+
+	enableSearch := cfg.Extra["enable_search"] == "true"
+
+	return &GeminiAdapter{
+		name:         cfg.Name,
+		baseURL:      baseURL,
+		apiKey:       cfg.APIKey,
+		model:        model,
+		systemPrompt: cfg.SystemPrompt,
+		maxTokens:    maxTokens,
+		temperature:  temperature,
+		enableSearch: enableSearch,
+		httpClient:   &http.Client{},
+		logger:       logger,
+	}
+}
+
+func (a *GeminiAdapter) Name() string { return a.name }
+func (a *GeminiAdapter) Type() string { return "gemini" }
+
+// buildRequest 构建 Gemini 请求
+func (a *GeminiAdapter) buildRequest(req *ChatRequest) *geminiRequest {
+	gemReq := &geminiRequest{
+		GenerationConfig: &geminiGenConfig{
+			MaxOutputTokens: a.maxTokens,
+			Temperature:     a.temperature,
+		},
+	}
+
+	// 系统提示词
+	if a.systemPrompt != "" {
+		gemReq.SystemInstruction = &geminiContent{
+			Parts: []geminiPart{{Text: a.systemPrompt}},
+		}
+	}
+
+	// 历史消息
+	for _, h := range req.History {
+		role := h.Role
+		if role == "assistant" {
+			role = "model" // Gemini 使用 "model" 而非 "assistant"
+		}
+		gemReq.Contents = append(gemReq.Contents, geminiContent{
+			Role:  role,
+			Parts: []geminiPart{{Text: h.Content}},
+		})
+	}
+
+	// 当前用户消息
+	gemReq.Contents = append(gemReq.Contents, geminiContent{
+		Role:  "user",
+		Parts: []geminiPart{{Text: req.Message}},
+	})
+
+	// 搜索工具
+	if a.enableSearch {
+		gemReq.Tools = []geminiTool{{GoogleSearch: &struct{}{}}}
+	}
+
+	return gemReq
+}
+
+// buildURL 构建 API URL
+func (a *GeminiAdapter) buildURL(stream bool) string {
+	action := "generateContent"
+	if stream {
+		action = "streamGenerateContent?alt=sse"
+	}
+	url := fmt.Sprintf("%s/v1beta/models/%s:%s", a.baseURL, a.model, action)
+	if a.apiKey != "" {
+		sep := "?"
+		if stream {
+			sep = "&"
+		}
+		url += sep + "key=" + a.apiKey
+	}
+	return url
+}
+
+// Chat 同步对话
+func (a *GeminiAdapter) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	gemReq := a.buildRequest(req)
+
+	body, err := json.Marshal(gemReq)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: 序列化请求失败: %w", err)
+	}
+
+	url := a.buildURL(false)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gemini: 创建请求失败: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: 请求失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: 读取响应失败: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gemini: HTTP %d: %s", resp.StatusCode, string(rawBody))
+	}
+
+	var gemResp geminiResponse
+	if err := json.Unmarshal(rawBody, &gemResp); err != nil {
+		return nil, fmt.Errorf("gemini: 解析响应失败: %w", err)
+	}
+
+	if gemResp.Error != nil {
+		return nil, fmt.Errorf("gemini: API 错误 (%d): %s", gemResp.Error.Code, gemResp.Error.Message)
+	}
+
+	if len(gemResp.Candidates) == 0 {
+		return nil, fmt.Errorf("gemini: 响应中没有 candidates")
+	}
+
+	// 拼接所有 parts 的文本
+	var text strings.Builder
+	for _, part := range gemResp.Candidates[0].Content.Parts {
+		text.WriteString(part.Text)
+	}
+
+	// 附加搜索来源（如果有）
+	result := text.String()
+	if gm := gemResp.Candidates[0].GroundingMetadata; gm != nil && len(gm.GroundingChunks) > 0 {
+		result += "\n\n📎 参考来源：\n"
+		for _, chunk := range gm.GroundingChunks {
+			if chunk.Web != nil {
+				result += fmt.Sprintf("- [%s](%s)\n", chunk.Web.Title, chunk.Web.URI)
+			}
+		}
+	}
+
+	return &ChatResponse{
+		Text: result,
+	}, nil
+}
+
+// ChatStream 流式对话
+func (a *GeminiAdapter) ChatStream(ctx context.Context, req *ChatRequest) (<-chan *ChatChunk, error) {
+	gemReq := a.buildRequest(req)
+
+	body, err := json.Marshal(gemReq)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: 序列化请求失败: %w", err)
+	}
+
+	url := a.buildURL(true)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gemini: 创建请求失败: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	resp, err := a.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("gemini: 请求失败: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		rawBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("gemini: HTTP %d: %s", resp.StatusCode, string(rawBody))
+	}
+
+	ch := make(chan *ChatChunk, 64)
+
+	go func() {
+		defer close(ch)
+		defer resp.Body.Close()
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "" {
+				continue
+			}
+
+			var gemResp geminiResponse
+			if err := json.Unmarshal([]byte(data), &gemResp); err != nil {
+				a.logger.Warn("gemini: 解析 SSE 数据失败",
+					"data", data,
+					"error", err,
+				)
+				continue
+			}
+
+			if len(gemResp.Candidates) > 0 {
+				for _, part := range gemResp.Candidates[0].Content.Parts {
+					if part.Text != "" {
+						ch <- &ChatChunk{Text: part.Text}
+					}
+				}
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			ch <- &ChatChunk{Error: err}
+		}
+
+		ch <- &ChatChunk{Done: true}
+	}()
+
+	return ch, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,7 @@ func (c *Config) Validate() error {
 
 		validTypes := map[string]bool{
 			"openai": true, "anthropic": true, "dify": true,
-			"coze": true, "webhook": true, "cli": true,
+			"coze": true, "webhook": true, "cli": true, "gemini": true,
 		}
 		if !validTypes[a.AdapterType] {
 			return fmt.Errorf("不支持的适配器类型: %s（支持: %s）",

--- a/web/src/pages/Adapters.tsx
+++ b/web/src/pages/Adapters.tsx
@@ -27,6 +27,7 @@ interface AdapterConfig {
 // 支持的适配器类型
 const ADAPTER_TYPES = [
   { value: 'openai', label: 'OpenAI 兼容', desc: '支持 OpenAI、DeepSeek、通义千问、Ollama 等' },
+  { value: 'gemini', label: 'Gemini', desc: 'Google Gemini API（支持搜索工具）' },
   { value: 'webhook', label: 'Webhook', desc: '转发到自定义 HTTP 端点（对接任意 Agent）' },
   { value: 'dify', label: 'Dify', desc: 'Dify Agent / 工作流' },
   { value: 'coze', label: 'Coze', desc: 'Coze Bot 平台' },
@@ -36,6 +37,7 @@ const ADAPTER_TYPES = [
 // 类型颜色映射
 const TYPE_COLORS: Record<string, 'default' | 'secondary' | 'outline'> = {
   openai: 'default',
+  gemini: 'default',
   webhook: 'secondary',
   dify: 'outline',
   coze: 'outline',
@@ -279,6 +281,52 @@ export function AdaptersPage({ onUpdate }: Props) {
                       rows={3}
                       placeholder="你是一个友好的微信助手..."
                     />
+                  </div>
+                </>
+              )}
+
+              {form.type === 'gemini' && (
+                <>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="gemini-model" className="text-right">模型</Label>
+                    <Input
+                      id="gemini-model"
+                      value={form.model}
+                      onChange={e => setForm({ ...form, model: e.target.value })}
+                      className="col-span-3"
+                      placeholder="gemini-2.5-flash-preview-04-17"
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-4 items-start gap-4">
+                    <Label htmlFor="gemini-prompt" className="text-right pt-3">系统提示</Label>
+                    <Textarea
+                      id="gemini-prompt"
+                      value={form.system_prompt}
+                      onChange={e => setForm({ ...form, system_prompt: e.target.value })}
+                      className="col-span-3"
+                      rows={3}
+                      placeholder="你是一个友好的微信助手..."
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label className="text-right">搜索工具</Label>
+                    <div className="col-span-3 flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        id="gemini-search"
+                        checked={form.extra?.enable_search === 'true'}
+                        onChange={e => setForm({
+                          ...form,
+                          extra: { ...form.extra, enable_search: e.target.checked ? 'true' : '' }
+                        })}
+                        className="h-4 w-4 rounded border-input"
+                      />
+                      <Label htmlFor="gemini-search" className="text-sm font-normal text-muted-foreground">
+                        启用 Google Search（AI 可联网搜索最新信息）
+                      </Label>
+                    </div>
                   </div>
                 </>
               )}


### PR DESCRIPTION
## 概述

新增 `gemini` 类型适配器，原生支持 Google Gemini API，并集成 `google_search` 搜索工具。

## 变更内容

### 后端
- **新增** `internal/adapter/gemini.go` — Gemini 原生适配器
  - `v1beta/models/{model}:generateContent` 端点
  - `systemInstruction` 系统提示词
  - `google_search` 搜索工具（通过 `extra.enable_search` 开关）
  - SSE 流式响应解析
  - 搜索来源（`groundingMetadata`）自动附加到回复
- **修改** `internal/config/config.go` — 添加 `gemini` 到有效类型
- **修改** `cmd/weclaw-proxy/main.go` — 适配器工厂注册 `GeminiAdapter`

### 前端
- **修改** `web/src/pages/Adapters.tsx` — 新增 Gemini 类型选项（模型、系统提示、搜索工具开关）

## 配置示例

```yaml
adapters:
  - name: "gemini-search"
    type: gemini
    api_key: "AIza..."
    model: "gemini-2.5-flash-preview-04-17"
    system_prompt: "你是一个友好的微信助手"
    extra:
      enable_search: "true"
```

Closes #3