### PR TITLE
fix(web): prevent agent edit dialog from overflowing viewport

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -51,7 +51,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 flex flex-col w-full max-w-[calc(100%-2rem)] max-h-[85vh] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/web/src/pages/Adapters.tsx
+++ b/web/src/pages/Adapters.tsx
@@ -171,7 +171,7 @@ export function AdaptersPage({ onUpdate }: Props) {
               </DialogDescription>
             </DialogHeader>
 
-            <div className="space-y-4 py-4">
+            <div className="space-y-4 py-4 overflow-y-auto flex-1 min-h-0">
               <div className="grid grid-cols-4 items-center gap-4">
                 <Label htmlFor="adapter-name" className="text-right">名称</Label>
                 <Input


### PR DESCRIPTION
## 问题

当系统提示词内容较长时，Agent 编辑 Dialog 高度超出浏览器视口，底部「取消」和「保存」按钮无法点击。

## 修复

- `DialogContent` 添加 `max-h-[85vh] flex flex-col` 限制最大高度
- `Adapters.tsx` 表单区域添加 `overflow-y-auto flex-1 min-h-0` 支持滚动

DialogHeader/DialogFooter 固定，表单区域可滚动，按钮始终可见。

Closes #7